### PR TITLE
Adds support for username and password flags to cqlsh

### DIFF
--- a/cmd/cain.go
+++ b/cmd/cain.go
@@ -47,6 +47,8 @@ type backupCmd struct {
 	parallel         int
 	bufferSize       float64
 	cassandraDataDir string
+	username         string
+	password         string
 
 	out io.Writer
 }
@@ -81,6 +83,8 @@ func NewBackupCmd(out io.Writer) *cobra.Command {
 				Parallel:         b.parallel,
 				BufferSize:       b.bufferSize,
 				CassandraDataDir: b.cassandraDataDir,
+				Username:         b.username,
+				Password:         b.password,
 			}
 			if _, err := cain.Backup(options); err != nil {
 				log.Fatal(err)
@@ -97,6 +101,8 @@ func NewBackupCmd(out io.Writer) *cobra.Command {
 	f.IntVarP(&b.parallel, "parallel", "p", utils.GetIntEnvVar("CAIN_PARALLEL", 1), "number of files to copy in parallel. set this flag to 0 for full parallelism. Overrides $CAIN_PARALLEL")
 	f.Float64VarP(&b.bufferSize, "buffer-size", "b", utils.GetFloat64EnvVar("CAIN_BUFFER_SIZE", 6.75), "in memory buffer size (MB) to use for files copy (buffer per file). Overrides $CAIN_BUFFER_SIZE")
 	f.StringVar(&b.cassandraDataDir, "cassandra-data-dir", utils.GetStringEnvVar("CAIN_CASSANDRA_DATA_DIR", "/var/lib/cassandra/data"), "cassandra data directory. Overrides $CAIN_CASSANDRA_DATA_DIR")
+	f.StringVarP(&b.username, "username", "u", utils.GetStringEnvVar("CAIN_USERNAME", "cassandra"), "username for the cassandra connection. Overrides $CAIN_USERNAME")
+	f.StringVarP(&b.password, "password", "w", utils.GetStringEnvVar("CAIN_PASSWORD", "cassandra"), "password for the cassandra connection. Overrides $CAIN_PASSWORD")
 
 	return cmd
 }
@@ -113,6 +119,8 @@ type restoreCmd struct {
 	bufferSize       float64
 	userGroup        string
 	cassandraDataDir string
+	username         string
+	password         string
 
 	out io.Writer
 }
@@ -153,6 +161,8 @@ func NewRestoreCmd(out io.Writer) *cobra.Command {
 				BufferSize:       r.bufferSize,
 				UserGroup:        r.userGroup,
 				CassandraDataDir: r.cassandraDataDir,
+				Username:         r.username,
+				Password:         r.password,
 			}
 			if err := cain.Restore(options); err != nil {
 				log.Fatal(err)
@@ -172,6 +182,8 @@ func NewRestoreCmd(out io.Writer) *cobra.Command {
 	f.Float64VarP(&r.bufferSize, "buffer-size", "b", utils.GetFloat64EnvVar("CAIN_BUFFER_SIZE", 6.75), "in memory buffer size (MB) to use for files copy (buffer per file). Overrides $CAIN_BUFFER_SIZE")
 	f.StringVar(&r.userGroup, "user-group", utils.GetStringEnvVar("CAIN_USER_GROUP", "cassandra:cassandra"), "user and group who should own restored files. Overrides $CAIN_USER_GROUP")
 	f.StringVar(&r.cassandraDataDir, "cassandra-data-dir", utils.GetStringEnvVar("CAIN_CASSANDRA_DATA_DIR", "/var/lib/cassandra/data"), "cassandra data directory. Overrides $CAIN_CASSANDRA_DATA_DIR")
+	f.StringVarP(&r.username, "username", "u", utils.GetStringEnvVar("CAIN_USERNAME", "cassandra"), "username for the cassandra connection. Overrides $CAIN_USERNAME")
+	f.StringVarP(&r.password, "password", "w", utils.GetStringEnvVar("CAIN_PASSWORD", "cassandra"), "password for the cassandra connection. Overrides $CAIN_PASSWORD")
 
 	return cmd
 }
@@ -182,6 +194,8 @@ type schemaCmd struct {
 	container string
 	keyspace  string
 	sum       bool
+	username  string
+	password  string
 
 	out io.Writer
 }
@@ -226,6 +240,8 @@ func NewSchemaCmd(out io.Writer) *cobra.Command {
 	f.StringVarP(&s.container, "container", "c", utils.GetStringEnvVar("CAIN_CONTAINER", "cassandra"), "container name to act on. Overrides $CAIN_CONTAINER")
 	f.StringVarP(&s.keyspace, "keyspace", "k", utils.GetStringEnvVar("CAIN_KEYSPACE", ""), "keyspace to act on. Overrides $CAIN_KEYSPACE")
 	f.BoolVar(&s.sum, "sum", utils.GetBoolEnvVar("CAIN_SUM", false), "print only checksum. Overrides $CAIN_SUM")
+	f.StringVarP(&s.username, "username", "u", utils.GetStringEnvVar("CAIN_USERNAME", "cassandra"), "username for the cassandra connection. Overrides $CAIN_USERNAME")
+	f.StringVarP(&s.password, "password", "w", utils.GetStringEnvVar("CAIN_PASSWORD", "cassandra"), "password for the cassandra connection. Overrides $CAIN_PASSWORD")
 
 	return cmd
 }

--- a/pkg/cain/cain.go
+++ b/pkg/cain/cain.go
@@ -19,6 +19,8 @@ type BackupOptions struct {
 	Parallel         int
 	BufferSize       float64
 	CassandraDataDir string
+	Username         string
+	Password         string
 }
 
 // Backup performs backup
@@ -48,13 +50,13 @@ func Backup(o BackupOptions) (string, error) {
 	}
 
 	log.Println("Backing up schema")
-	dstBasePath, err := BackupKeyspaceSchema(k8sClient, dstClient, o.Namespace, pods[0], o.Container, o.Keyspace, dstPrefix, dstPath)
+	dstBasePath, err := BackupKeyspaceSchema(k8sClient, dstClient, o.Namespace, pods[0], o.Container, o.Keyspace, o.Username, o.Password, dstPrefix, dstPath)
 	if err != nil {
 		return "", err
 	}
 
 	log.Println("Taking snapshots")
-	tag := TakeSnapshots(k8sClient, pods, o.Namespace, o.Container, o.Keyspace)
+	tag := TakeSnapshots(k8sClient, pods, o.Namespace, o.Container, o.Keyspace, o.Username, o.Password)
 
 	log.Println("Calculating paths. This may take a while...")
 	fromToPathsAllPods, err := utils.GetFromAndToPathsFromK8s(k8sClient, pods, o.Namespace, o.Container, o.Keyspace, tag, dstBasePath, o.CassandraDataDir)
@@ -87,6 +89,8 @@ type RestoreOptions struct {
 	BufferSize       float64
 	UserGroup        string
 	CassandraDataDir string
+	Username         string
+	Password         string
 }
 
 // Restore performs restore
@@ -112,13 +116,13 @@ func Restore(o RestoreOptions) error {
 	}
 
 	log.Println("Getting current schema")
-	_, sum, err := DescribeKeyspaceSchema(k8sClient, o.Namespace, existingPods[0], o.Container, o.Keyspace)
+	_, sum, err := DescribeKeyspaceSchema(k8sClient, o.Namespace, existingPods[0], o.Container, o.Keyspace, o.Username, o.Password)
 	if err != nil {
 		if o.Schema == "" {
 			return err
 		}
 		log.Println("Schema not found, restoring schema", o.Schema)
-		sum, err = RestoreKeyspaceSchema(srcClient, k8sClient, srcPrefix, srcBasePath, o.Namespace, existingPods[0], o.Container, o.Keyspace, o.Schema, o.Parallel, o.BufferSize)
+		sum, err = RestoreKeyspaceSchema(srcClient, k8sClient, srcPrefix, srcBasePath, o.Namespace, existingPods[0], o.Container, o.Keyspace, o.Username, o.Password, o.Schema, o.Parallel, o.BufferSize)
 		if err != nil {
 			return err
 		}
@@ -144,13 +148,13 @@ func Restore(o RestoreOptions) error {
 	}
 
 	log.Println("Getting materialized views to exclude")
-	materializedViews, err := GetMaterializedViews(k8sClient, o.Namespace, o.Container, existingPods[0], o.Keyspace)
+	materializedViews, err := GetMaterializedViews(k8sClient, o.Namespace, o.Container, existingPods[0], o.Keyspace, o.Username, o.Password)
 	if err != nil {
 		return err
 	}
 
 	log.Println("Truncating tables")
-	TruncateTables(k8sClient, o.Namespace, o.Container, o.Keyspace, existingPods, tablesToRefresh, materializedViews)
+	TruncateTables(k8sClient, o.Namespace, o.Container, o.Keyspace, o.Username, o.Password, existingPods, tablesToRefresh, materializedViews)
 
 	log.Println("Starting files copy")
 	if err := skbn.PerformCopy(srcClient, k8sClient, srcPrefix, "k8s", fromToPaths, o.Parallel, o.BufferSize); err != nil {
@@ -175,6 +179,8 @@ type SchemaOptions struct {
 	Selector  string
 	Container string
 	Keyspace  string
+	Username  string
+	Password  string
 }
 
 // Schema gets the schema of the cassandra cluster
@@ -187,7 +193,7 @@ func Schema(o SchemaOptions) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	schema, sum, err := DescribeKeyspaceSchema(k8sClient, o.Namespace, pods[0], o.Container, o.Keyspace)
+	schema, sum, err := DescribeKeyspaceSchema(k8sClient, o.Namespace, pods[0], o.Container, o.Keyspace, o.Username, o.Password)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
This PR adds support for new flags (`-u`, `--username` and `-w`, `--password`) for providing authorization information to the cqlsh command.

This is not an issue in a default cassandra configuration, but with modified authenticator (as is the case when using the [Ericsson/ecaudit](https://github.com/Ericsson/ecaudit)) which forces authentication an all commands and connections, the current implementation of the `cqlsh` wrapper is failing.

Review the changes I did, and I'll be available to refactor or help improve them if needed.

Thanks.