### PR TITLE
Backup tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Flags:
   -p, --parallel int                number of files to copy in parallel. set this flag to 0 for full parallelism. Overrides $CAIN_PARALLEL (default 1)
   -w, --password string             password for the cassandra connection. Overrides $CAIN_PASSWORD (default "cassandra")
   -l, --selector string             selector to filter on. Overrides $CAIN_SELECTOR (default "app=cassandra")
-  -t, --tag string                  tag to backup, if empty then will use current timestamp. Use with cauthon - if tag exists then its contents will be overwritten. Overrides $CAIN_TAG
+  -t, --tag string                  tag to backup, if empty then will use current timestamp. Use with caution - if tag exists then its contents will be overwritten. Overrides $CAIN_TAG
   -u, --username string             username for the cassandra connection. Overrides $CAIN_USERNAME (default "cassandra")
 
 ```
@@ -142,9 +142,10 @@ Flags:
   -p, --parallel int                number of files to copy in parallel. set this flag to 0 for full parallelism. Overrides $CAIN_PARALLEL (default 1)
   -s, --schema string               schema version to restore (optional). Overrides $CAIN_SCHEMA
   -l, --selector string             selector to filter on. Overrides $CAIN_SELECTOR (default "app=cassandra")
-      --src string                  source to restore from. Example: s3://bucket/cassandra/namespace/cluster-name. Overrides $CAIN_SRC
+      --src string                  source to restore from. Example: s3://bucket/cassandra/namespace/cluster-name. Notice that the src should not end with the forward slash. Overrides $CAIN_SRC
   -t, --tag string                  tag to restore. Overrides $CAIN_TAG
-      --user-group string           user and group who should own restored files. Overrides $CAIN_USER_GROUP (default "cassandra:cassandra")
+      --user-group string           user and group who should own restored files. Overrides $CAIN_USER_GROUP (default "cassandra:cassandra").
+        If you use rootless containers then ensure to set exactly the same user and group (by name or number) as in target container.
 ```
 
 #### Examples
@@ -244,7 +245,7 @@ cain backup \
     --dst s3://db-backup/cassandra
 ```
 
-You can also set the appropriate envrionment variables (`CAIN_FLAG`, `_` instead of `-`):
+You can also set the appropriate environment variables (`CAIN_FLAG`, `_` instead of `-`):
 
 ```shell
 export CAIN_NAMESPACE=default
@@ -293,8 +294,8 @@ Cain uses `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_ACCESS_KEY` environment var
 
 ### Google Cloud Storage
 
-Cain uses Google [Application Default Credentials](https://cloud.google.com/docs/authentication/production). 
-Basically, it will first look for the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. If it is not defined, it will look for the default service account, or throw an error if none is configured. 
+Cain uses Google [Application Default Credentials](https://cloud.google.com/docs/authentication/production).
+Basically, it will first look for the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. If it is not defined, it will look for the default service account, or throw an error if none is configured.
 
 ## Examples
 

--- a/cmd/cain.go
+++ b/cmd/cain.go
@@ -105,7 +105,7 @@ func NewBackupCmd(out io.Writer) *cobra.Command {
 	f.StringVar(&b.cassandraDataDir, "cassandra-data-dir", utils.GetStringEnvVar("CAIN_CASSANDRA_DATA_DIR", "/var/lib/cassandra/data"), "cassandra data directory. Overrides $CAIN_CASSANDRA_DATA_DIR")
 	f.StringVarP(&b.username, "username", "u", utils.GetStringEnvVar("CAIN_USERNAME", "cassandra"), "username for the cassandra connection. Overrides $CAIN_USERNAME")
 	f.StringVarP(&b.password, "password", "w", utils.GetStringEnvVar("CAIN_PASSWORD", "cassandra"), "password for the cassandra connection. Overrides $CAIN_PASSWORD")
-	f.StringVarP(&b.tag, "tag", "t", utils.GetStringEnvVar("CAIN_TAG", ""), "tag to backup, if empty then will use current timestamp. Overrides $CAIN_TAG")
+	f.StringVarP(&b.tag, "tag", "t", utils.GetStringEnvVar("CAIN_TAG", ""), "tag to backup, if empty then will use current timestamp. Use with cauthon - if tag exists then its contents will be overwritten. Overrides $CAIN_TAG")
 
 	return cmd
 }

--- a/cmd/cain.go
+++ b/cmd/cain.go
@@ -49,6 +49,7 @@ type backupCmd struct {
 	cassandraDataDir string
 	username         string
 	password         string
+	tag              string
 
 	out io.Writer
 }
@@ -85,6 +86,7 @@ func NewBackupCmd(out io.Writer) *cobra.Command {
 				CassandraDataDir: b.cassandraDataDir,
 				Username:         b.username,
 				Password:         b.password,
+				Tag:              b.tag,
 			}
 			if _, err := cain.Backup(options); err != nil {
 				log.Fatal(err)
@@ -103,6 +105,7 @@ func NewBackupCmd(out io.Writer) *cobra.Command {
 	f.StringVar(&b.cassandraDataDir, "cassandra-data-dir", utils.GetStringEnvVar("CAIN_CASSANDRA_DATA_DIR", "/var/lib/cassandra/data"), "cassandra data directory. Overrides $CAIN_CASSANDRA_DATA_DIR")
 	f.StringVarP(&b.username, "username", "u", utils.GetStringEnvVar("CAIN_USERNAME", "cassandra"), "username for the cassandra connection. Overrides $CAIN_USERNAME")
 	f.StringVarP(&b.password, "password", "w", utils.GetStringEnvVar("CAIN_PASSWORD", "cassandra"), "password for the cassandra connection. Overrides $CAIN_PASSWORD")
+	f.StringVarP(&b.tag, "tag", "t", utils.GetStringEnvVar("CAIN_TAG", ""), "tag to backup, if empty then will use current timestamp. Overrides $CAIN_TAG")
 
 	return cmd
 }

--- a/pkg/cain/cain.go
+++ b/pkg/cain/cain.go
@@ -21,6 +21,7 @@ type BackupOptions struct {
 	CassandraDataDir string
 	Username         string
 	Password         string
+	Tag              string
 }
 
 // Backup performs backup
@@ -56,7 +57,7 @@ func Backup(o BackupOptions) (string, error) {
 	}
 
 	log.Println("Taking snapshots")
-	tag := TakeSnapshots(k8sClient, pods, o.Namespace, o.Container, o.Keyspace, o.Username, o.Password)
+	tag := TakeSnapshots(k8sClient, pods, o.Namespace, o.Container, o.Keyspace, o.Username, o.Password, o.Tag)
 
 	log.Println("Calculating paths. This may take a while...")
 	fromToPathsAllPods, err := utils.GetFromAndToPathsFromK8s(k8sClient, pods, o.Namespace, o.Container, o.Keyspace, tag, dstBasePath, o.CassandraDataDir)

--- a/pkg/cain/nodetool.go
+++ b/pkg/cain/nodetool.go
@@ -13,10 +13,14 @@ import (
 // TakeSnapshots takes a snapshot using nodetool in all pods in parallel
 func TakeSnapshots(iClient interface{}, pods []string, namespace, container, keyspace string, username string, password string, tag string) string {
 	k8sClient := iClient.(*skbn.K8sClient)
+
+	// get current time as tag
 	realtag := utils.GetTimeStamp()
-	if len(tag) == 0 {
+	// set custom tag if provided
+	if len(tag) != 0 {
 		realtag = tag
 	}
+
 	bwgSize := len(pods)
 	bwg := utils.NewBoundedWaitGroup(bwgSize)
 	for _, pod := range pods {


### PR DESCRIPTION
Partially implements #9
- allow to pass `--tag` as param (or $CAIN_TAG) to use as named tag when creating backup
- if the tag already exists then it will be overwritten, use with caution